### PR TITLE
Update Node and react-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "node": "18.x.x"
   },
   "dependencies": {
+    "@babel/plugin-syntax-flow": "7.14.5",
+    "@babel/plugin-transform-react-jsx":"7.14.9",
     "concurrently": "^4.1.2",
     "cors": "^2.8.5",
     "dotenv": "^8.1.0",
@@ -39,7 +41,7 @@
     "ts-node": "^10.7.0"
   },
   "resolutions": {
-    "react-error-overlay": "6.0.9"
+    "react-error-overlay": "6.x.x"
   },
   "scripts": {
     "build": "npm run build-frontend && npm run build-backend",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.7",
   "private": true,
   "engines": {
-    "node": "16.x.x"
+    "node": "18.x.x"
   },
   "dependencies": {
     "concurrently": "^4.1.2",
@@ -22,7 +22,7 @@
     "react": "^16.9.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^16.9.0",
-    "react-scripts": "3.4.1",
+    "react-scripts": "5.x.x",
     "sass": "^1.52.1",
     "typescript": "^4.1.3",
     "web3": "^1.8.1"


### PR DESCRIPTION
Issue: Current version of the software requires using an old version of react, 16.x.x, to run while the latest version of Node is 18 as of this writing. This PR will allow the app to use the latest version of Node.